### PR TITLE
Explicitly defined CORS paths

### DIFF
--- a/src/main/kotlin/com/ulu/fetchers/RatingFetcher.kt
+++ b/src/main/kotlin/com/ulu/fetchers/RatingFetcher.kt
@@ -102,7 +102,7 @@ class RatingFetcher(
         val seenIds : MutableList<Long> = mutableListOf()
         inputs.forEach { attributeInput: Map<String, *> ->
             // Find category by id
-            val attributeCategoryId = attributeInput["id"] as Long
+            val attributeCategoryId = (attributeInput["id"] as String).toLong()
             if (seenIds.contains(attributeCategoryId)){
                 error("Can not give same attribute category a score multiple times!")
             }

--- a/src/main/kotlin/com/ulu/services/AccountCreationService.kt
+++ b/src/main/kotlin/com/ulu/services/AccountCreationService.kt
@@ -8,7 +8,7 @@ import jakarta.inject.Singleton
  *
  * Random salt will be added to the passwords internally by BCrypt.
  * */
-private const val MIN_PASSWORD_LENGTH = 10
+private const val MIN_PASSWORD_LENGTH = 8
 @Singleton
 class AccountCreationService {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,14 @@ micronaut:
           allowedHeaders:
             - Content-Type
             - Authorization
-          allowCredentials: true
+          allowCredentials:
+            true
+          allowedPaths:
+            - "/oauth/access_token"
+            - "/login"
+            - "/logout"
+            - "/register"
+            - "/graphql"
   security:
     token:
       jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ micronaut:
             - https://unrated.no
             - http://unrated.no
           allowedMethods:
+            - OPTIONS
             - POST
           allowedHeaders:
             - Content-Type

--- a/src/test/kotlin/com/ulu/graphql/AttributeCategoryTest.kt
+++ b/src/test/kotlin/com/ulu/graphql/AttributeCategoryTest.kt
@@ -97,7 +97,7 @@ class AttributeCategoryTest(@Client("/") private val client: HttpClient, private
     }
 
     @Test
-    fun createRatingTest() {
+    fun createAttributeCategoryTest() {
         val query =
             """ { "query": "mutation{ createAttributeCategory(name: \"New AttributeCategory created!\") { id, name } }" }" """
         val body = makeRequest(query)
@@ -113,7 +113,7 @@ class AttributeCategoryTest(@Client("/") private val client: HttpClient, private
     }
 
     @Test
-    fun deleteRatingTest() {
+    fun deleteAttributeCategoryTest() {
         val query = """ { "query": "mutation{ deleteAttributeCategory(id: \"${attributeCategory?.id}\") }" } """
         val body = makeRequest(query)
 


### PR DESCRIPTION
This PR includes:
- Added CORS configuration to all application paths (/login, /register, /graphql etc). 
- Excluding /graphiql since it should only be accessed directly and for debugging.^

As well as:
- Fixed a bug that prevented from adding Attributes to a review
- Unit tests for Attributes fixed