### PR TITLE
Whiskey filters

### DIFF
--- a/src/main/kotlin/com/ulu/Application.kt
+++ b/src/main/kotlin/com/ulu/Application.kt
@@ -32,7 +32,7 @@ class TestDataCreator(private val dbService: DatabaseService, private val userDa
     lateinit var adminPass: String
 
     @EventListener
-    @Requires(notEnv = ["prod"])
+    @Requires(notEnv = ["prod", "test"])
     fun onStartup(event: StartupEvent) {
         if (userDataRepository.getUserDataByName("Jeff") != null) {
             return
@@ -65,6 +65,15 @@ class TestDataCreator(private val dbService: DatabaseService, private val userDa
             Whiskey(img = "test.com/img", title = "Test", price = 199.6, summary = "its a whiskey", volume = 1.5, percentage = 99.9)
         val whiskey2 =
             Whiskey(img = "test2.com/img", title = "Test2", price = 5.0, summary = "it is another whiskey", volume = 0.4, percentage = 21.0)
+        val whiskey3 =
+            Whiskey(
+                img = "test3.com/img",
+                title = "Test3",
+                price = 100.0,
+                summary = "it is yet another whiskey",
+                volume = 0.5,
+                percentage = 20.0,
+            )
 
         // Create ratings
         val rating1 = Rating(body = "test", score = 0.1, title = "its drinkable", user = user1, whiskey = whiskey1)
@@ -88,6 +97,7 @@ class TestDataCreator(private val dbService: DatabaseService, private val userDa
 
         dbService.save(whiskey1)
         dbService.save(whiskey2)
+        dbService.save(whiskey3)
 
         dbService.save(rating1)
         dbService.save(rating2)

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -29,7 +29,7 @@ type Query{
     getRating(id: ID!) : Rating
 
     # Get a list of whiskeys based on sortType seperated by paging: {page: 0, size: 10}
-    getWhiskeys(sortType : SortType, filters: [Filter], paging: Paging): [Whiskey]
+    getWhiskeys(sort: Sort, filters: [Filter], paging: Paging): [Whiskey]
 
     # Get a list of users that match the query name
     getUsers(name: String!, paging: Paging) : [User]
@@ -62,6 +62,12 @@ type Mutation{
 }
 
 ######################################
+
+# Sort using a sorting type as defined in enum + reversed boolean
+input Sort{
+    sortType: SortType!
+    reverse: Boolean
+}
 
 # Filter whiskey using a comparator and a field value.
 input Filter {

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -7,6 +7,15 @@ enum SortType{
     #PERSONALIZED # Get "AI" recommended based on user preferences
 }
 
+enum Comparator {
+    LT, # Less than
+    GT, # Greater than
+    LE, # Less than or equal
+    GE, # Greater than or equal
+    EQ  # Equals
+}
+
+
 type Query{
     # Get logged in user using JWT
     getLoggedInUser : AuthUser
@@ -20,7 +29,7 @@ type Query{
     getRating(id: ID!) : Rating
 
     # Get a list of whiskeys based on sortType seperated by paging: {page: 0, size: 10}
-    getWhiskeys(sortType : SortType, paging: Paging): [Whiskey]
+    getWhiskeys(sortType : SortType, filters: [Filter], paging: Paging): [Whiskey]
 
     # Get a list of users that match the query name
     getUsers(name: String!, paging: Paging) : [User]
@@ -42,7 +51,6 @@ type Mutation{
     editThumb(id: ID!, isGood: Boolean!): Thumb
     deleteThumb(id: ID!) : String
 
-
     # Requires ROLE_ADMIN
     createWhiskey(whiskeyInput : WhiskeyInput!) : Whiskey
     editWhiskey(id: ID!, whiskeyInput : WhiskeyInput) : Whiskey
@@ -54,6 +62,25 @@ type Mutation{
 }
 
 ######################################
+
+# Filter whiskey using a comparator and a field value.
+input Filter {
+    comp: Comparator,
+    field: Field!
+}
+
+# What to compare against
+# Only the first one of these will be used for each given filter
+input Field {
+    title: String,            # Filter by whiskey name (does not need comparator)
+    avgScore: Float,          # Avg whiskey score
+    attribute: InputAttribute # Filter by an attribute
+}
+
+input InputAttribute{
+    id : Int!        # Attribute category ID
+    avgScore: Float! # Attribute average score value
+}
 
 input Paging{
     page: Int = 0


### PR DESCRIPTION
### This PR includes:
- Adds optional filters to the `getWhiskeys` graphql query function.
- Changes sorting to be a own input type with optional `reverse` property

The filters where initially outlined by @Neelzee in the related [issue.](https://github.com/Unrated-Limited-Unlimited/ua-backend/issues/32)

This implementation looks like:
```graphql
getWhiskeys(sort: Sort, filters: [Filter], paging: Paging): [Whiskey]
```
Where Sort is defined by:
```graphql
input Sort{
    sortType: SortType!
    reverse: Boolean
}

enum SortType{
    BEST,
    PRICE,
    POPULAR,
    RANDOM,
    DEFAULT,
}
```

The filtering looks mostly the same as the inital outline with some minor naming and null-able changes:

```graphql
# Filter whiskey using a comparator and a field value.
input Filter {
    comp: Comparator,
    field: Field!
}

# What to compare against
# Only the first one of these will be used for each given filter
input Field {
    title: String,            # Filter by whiskey name (does not need comparator)
    avgScore: Float,          # Avg whiskey score
    attribute: InputAttribute # Filter by an attribute
}

input InputAttribute{
    id : Int!        # Attribute category ID
    avgScore: Float! # Attribute average score value
}

enum Comparator {
    LT, # Less than
    GT, # Greater than
    LE, # Less than or equal
    GE, # Greater than or equal
    EQ  # Equals
}
```
An example using the filters to get every whiskey that has `malt` in title and has an average rating of Greater Than `0.4` (2 stars). The resulting whiskeys are sorted by `PRICE` in `reverse`/increasing order:
```graphql
query{
  getWhiskeys(
    sort: {sortType: PRICE, reverse: true}
    filters: [ {comp: GT, field: {avgScore: 0.4}}, {field: {title: "malt"}} ]
    paging: {page: 0, size: 12}
  ) {
    title
    price
    avgScore
    categories {
      id
      name
      avgScore
    }
  }
}
```
Paging remains unchanged with default values `{page: 0, size: 10}`, when not given as input.