### PR TITLE
Allow uploading of different image types + User.img is updated on profile image change.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 version = "0.1"
 group = "com.ulu"
 
-val kotlinVersion=project.properties.get("kotlinVersion")
+val kotlinVersion = project.properties["kotlinVersion"]
 repositories {
     mavenCentral()
 }
@@ -28,28 +28,27 @@ dependencies {
 
     implementation("at.favre.lib:bcrypt:0.10.2")
     implementation("org.yaml:snakeyaml")
-    //implementation("com.graphql-java-kickstart:graphql-java-tools")
 
     implementation("io.micronaut.kotlin:micronaut-kotlin-runtime")
     implementation("io.micronaut.security:micronaut-security-jwt")
     implementation("io.micronaut.sql:micronaut-jdbc-hikari")
     implementation("io.micronaut.data:micronaut-data-tx-hibernate")
 
-    implementation("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:${kotlinVersion}")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
     compileOnly("io.micronaut:micronaut-http-client")
     compileOnly("io.micronaut.openapi:micronaut-openapi-annotations")
     runtimeOnly("ch.qos.logback:logback-classic")
     runtimeOnly("com.fasterxml.jackson.module:jackson-module-kotlin")
+
     runtimeOnly("org.postgresql:postgresql")
 
-    runtimeOnly("com.h2database:h2") //For testing JPA local
+    runtimeOnly("com.h2database:h2") // For testing JPA local
 
     testImplementation("io.micronaut:micronaut-http-client")
     aotPlugins(platform("io.micronaut.platform:micronaut-platform:4.3.2"))
     aotPlugins("io.micronaut.security:micronaut-security-aot")
 }
-
 
 application {
     mainClass.set("com.ulu.ApplicationKt")
@@ -57,7 +56,6 @@ application {
 java {
     sourceCompatibility = JavaVersion.toVersion("17")
 }
-
 
 graalvmNative.toolchainDetection.set(false)
 micronaut {
@@ -68,8 +66,8 @@ micronaut {
         annotations("com.ulu.*")
     }
     aot {
-    // Please review carefully the optimizations enabled below
-    // Check https://micronaut-projects.github.io/micronaut-aot/latest/guide/ for more details
+        // Please review carefully the optimizations enabled below
+        // Check https://micronaut-projects.github.io/micronaut-aot/latest/guide/ for more details
         optimizeServiceLoading.set(false)
         convertYamlToJava.set(false)
         precomputeOperations.set(true)
@@ -77,9 +75,6 @@ micronaut {
         optimizeClassLoading.set(true)
         deduceEnvironment.set(true)
         optimizeNetty.set(true)
-        configurationProperties.put("micronaut.security.jwks.enabled","false")
+        configurationProperties.put("micronaut.security.jwks.enabled", "false")
     }
 }
-
-
-

--- a/src/main/kotlin/com/ulu/Application.kt
+++ b/src/main/kotlin/com/ulu/Application.kt
@@ -47,7 +47,6 @@ class TestDataCreator(private val dbService: DatabaseService, private val userDa
                 name = "Jeff",
                 email = "jeff@bank.no",
                 password = AccountCreationService().hashPassword("123"),
-                img = "www.test.com/1.png",
             )
         val user2 =
             UserData(

--- a/src/main/kotlin/com/ulu/controllers/AuthController.kt
+++ b/src/main/kotlin/com/ulu/controllers/AuthController.kt
@@ -28,14 +28,13 @@ import io.micronaut.security.utils.DefaultSecurityService
 class AuthController(
     private val securityService: DefaultSecurityService,
     private val userDataRepository: UserDataRepository,
-    private val jwtRefreshTokenRepository: JwtRefreshTokenRepository
+    private val jwtRefreshTokenRepository: JwtRefreshTokenRepository,
 ) {
     // Default /login uses username instead of name
     data class RegisterDTO(
         val username: String,
         val password: String,
         val email: String,
-        val img: String?
     )
 
     @Secured(SecurityRule.IS_AUTHENTICATED)
@@ -48,7 +47,9 @@ class AuthController(
 
     @Secured(SecurityRule.IS_ANONYMOUS)
     @Post("/register")
-    fun register(@Body registerData: RegisterDTO): HttpResponse<*> {
+    fun register(
+        @Body registerData: RegisterDTO,
+    ): HttpResponse<*> {
         if (userDataRepository.existsByName(registerData.username)) {
             return HttpResponse.badRequest("Username already taken!")
         }
@@ -60,12 +61,12 @@ class AuthController(
         }
 
         // Create new account
-        val userData = UserData(
-            name = registerData.username,
-            password = AccountCreationService().hashPassword(registerData.password),
-            email = registerData.email,
-            img = registerData.img
-        )
+        val userData =
+            UserData(
+                name = registerData.username,
+                password = AccountCreationService().hashPassword(registerData.password),
+                email = registerData.email,
+            )
         userDataRepository.save(userData)
 
         return HttpResponse.created("New account created.")

--- a/src/main/kotlin/com/ulu/controllers/ImageController.kt
+++ b/src/main/kotlin/com/ulu/controllers/ImageController.kt
@@ -81,6 +81,7 @@ class ImageController(
         try {
             val username = securityService.authentication.get().name
             val user = userDataRepository.getUserDataByName(username)
+
             return if (user == null) {
                 HttpResponse.badRequest("No user found for the provided credentials.")
             } else {
@@ -92,6 +93,10 @@ class ImageController(
                 if (response.code() != 200) {
                     return HttpResponse.serverError("Could not upload image to file storage ${response.code()}")
                 }
+                // Update user image
+                user.img = "p$id"
+                userDataRepository.update(user)
+
                 HttpResponse.ok("Image successfully uploaded with status: ${response.status}")
             }
         } catch (e: Exception) {

--- a/src/main/kotlin/com/ulu/fetchers/UserDataFetcher.kt
+++ b/src/main/kotlin/com/ulu/fetchers/UserDataFetcher.kt
@@ -62,10 +62,6 @@ class UserDataFetcher(
                 }
                 userData.password = accountCreationService.hashPassword(newPass)
             }
-
-            editUserMap["img"]?.let { newImg ->
-                userData.img = newImg as String
-            }
             // Revoke all issued jwt tokens
             jwtRefreshTokenRepository.updateRevokedByUsername(username, true)
             return@DataFetcher userDataRepository.update(userData)

--- a/src/main/kotlin/com/ulu/models/UserData.kt
+++ b/src/main/kotlin/com/ulu/models/UserData.kt
@@ -8,20 +8,16 @@ class UserData(
     @Id
     @GeneratedValue
     val id: Long? = null,
-
     @Column(unique = true)
     var name: String,
     var email: String,
     var password: String,
-    var img: String?,   //Store bytes?
+    var img: String? = null, // Store image id
     val createdAt: Instant = Instant.now(),
-
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "user", orphanRemoval = true)
     val ratings: MutableList<Rating> = mutableListOf(),
-
     @OneToMany(fetch = FetchType.EAGER, mappedBy = "user", orphanRemoval = true)
     var thumbs: MutableList<Thumb> = mutableListOf(),
-
     @ElementCollection(fetch = FetchType.EAGER)
-    val roles : MutableList<String> = mutableListOf("ROLE_USER")
+    val roles: MutableList<String> = mutableListOf("ROLE_USER"),
 )

--- a/src/main/kotlin/com/ulu/services/UploadService.kt
+++ b/src/main/kotlin/com/ulu/services/UploadService.kt
@@ -44,8 +44,6 @@ class UploadService {
      * Convert the uploaded image file to jpeg byte array.
      * */
     fun imageToJpegByteArray(imageBytes: ByteArray): ByteArray? {
-        println(imageBytes.size)
-
         // Convert ByteArray to BufferedImage
         val inputStream = ByteArrayInputStream(imageBytes)
         val image: BufferedImage? = ImageIO.read(inputStream)

--- a/src/main/kotlin/com/ulu/services/UploadService.kt
+++ b/src/main/kotlin/com/ulu/services/UploadService.kt
@@ -9,12 +9,14 @@ import io.micronaut.http.multipart.CompletedFileUpload
 import jakarta.inject.Inject
 import jakarta.inject.Singleton
 import reactor.core.publisher.Mono
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
 
 @Singleton
 class UploadService {
-    private val maxImageSizeMb = 10 // Set upload limit.
-    private val maxImageSizeByte = maxImageSizeMb * 1024 * 1024
-
     @Inject
     @field:Client("http://localhost:8001") // Base url for file storage server.
     lateinit var client: HttpClient
@@ -32,27 +34,51 @@ class UploadService {
     }
 
     /**
-     * Verify upload attempt by checking size and type is jpeg.
+     * Verify upload attempt by checking size and type is image.
      * */
-    fun verifyUpload(fileUpload: CompletedFileUpload): HttpResponse<String>? {
-        val imageBytes = fileUpload.bytes
-        println("Received image with size: ${imageBytes.size} bytes")
-        if (fileUpload.contentType.get().name != MediaType.IMAGE_JPEG) {
-            return HttpResponse.badRequest("MediaType must be of ${MediaType.IMAGE_JPEG}")
-        }
-        if (!fileUpload.filename.endsWith(".jpeg", ignoreCase = true) && !fileUpload.filename.endsWith(".jpg", ignoreCase = true)) {
-            return HttpResponse.badRequest("Uploaded file must be of filetype jpeg/jpg!")
-        }
-        if (verifySize(imageBytes)) {
-            return HttpResponse.badRequest("Image size exceeds the maximum allowed limit of ${maxImageSizeMb}MB")
-        }
-        return null
+    fun isUploadedFileImage(fileUpload: CompletedFileUpload): Boolean {
+        return !(!fileUpload.contentType.isPresent || !fileUpload.contentType.get().name.startsWith("image/"))
     }
 
     /**
-     * Limit size of upload.
+     * Convert the uploaded image file to jpeg byte array.
      * */
-    private fun verifySize(imageBytes: ByteArray): Boolean {
-        return imageBytes.size > maxImageSizeByte
+    fun imageToJpegByteArray(imageBytes: ByteArray): ByteArray? {
+        println(imageBytes.size)
+
+        // Convert ByteArray to BufferedImage
+        val inputStream = ByteArrayInputStream(imageBytes)
+        val image: BufferedImage? = ImageIO.read(inputStream)
+        if (image == null) {
+            println("Image buffer empty")
+            return null
+        }
+
+        // Prepare output stream to capture the output bytes
+        val outputStream = ByteArrayOutputStream()
+
+        // Write the image as a JPEG
+        val writer = ImageIO.write(convertToJpeg(image), "JPEG", outputStream)
+        if (!writer) {
+            println("No writer found.")
+            return null
+        }
+
+        // Convert ByteArrayOutputStream to ByteArray
+        return outputStream.toByteArray()
+    }
+
+    /**
+     * Remove transparent features from image.
+     * */
+    private fun convertToJpeg(inputImage: BufferedImage): BufferedImage {
+        // Create a new RGB buffered image
+        val newImage = BufferedImage(inputImage.width, inputImage.height, BufferedImage.TYPE_INT_RGB)
+        // Draw the input image on the new image, handling transparency
+        newImage.createGraphics().apply {
+            drawImage(inputImage, 0, 0, Color.WHITE, null)
+            dispose()
+        }
+        return newImage
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,11 @@ micronaut:
             - "/logout"
             - "/register"
             - "/graphql"
+
+    multipart:
+      enabled: true
+      max-file-size: 10485760 # 10MB limit in bytes
+
   security:
     token:
       jwt:

--- a/src/main/resources/schema.graphqls
+++ b/src/main/resources/schema.graphqls
@@ -109,7 +109,7 @@ input AttributeInput{
 input EditUserInput{
     email: String
     password: String
-    img: String
+    img: String # Deprecated; Image is updated through POST img/profile
 }
 
 input WhiskeyInput{


### PR DESCRIPTION
The image endpoints `/img/whiskey/{id}` and `/img/profile` now supports all `image/*` types (PNG, GIF, etc.).
It will try to convert any image type to JPG and store it in FISO.

The default value of User.img is now set to `null`. 
This value will be updated when a user uploads an image to the image prefix `p` + user_id.
The value can no longer be changed through `/registrer` and the `editUser` mutation function.