### PR TITLE
Bug fixes: Paging with filtering bug + getWhiskey(id) query bug + overshadowed logout endpoint

### DIFF
--- a/src/main/kotlin/com/ulu/controllers/AuthController.kt
+++ b/src/main/kotlin/com/ulu/controllers/AuthController.kt
@@ -6,6 +6,7 @@ import io.micronaut.http.HttpResponse
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Post
+import io.micronaut.http.cookie.Cookie
 import io.micronaut.security.annotation.Secured
 import io.micronaut.security.rules.SecurityRule
 import io.micronaut.security.utils.DefaultSecurityService
@@ -38,7 +39,12 @@ class AuthController(
     fun logout(): HttpResponse<*> {
         // Invalidates all sessions.
         accountService.invalidateSessions(securityService.authentication.get().name)
-        return HttpResponse.ok("All sessions logged out!")
+
+        // Max age set to 0 to expire immediately
+        val emptyJwtCookie = Cookie.of("JWT", "").maxAge(0)
+        val emptyJwtRefreshCookie = Cookie.of("JWT_REFRESH_TOKEN", "").path("/oauth/access_token").maxAge(0)
+
+        return HttpResponse.ok("All sessions logged out!").cookie(emptyJwtCookie).cookie(emptyJwtRefreshCookie)
     }
 
     @Secured(SecurityRule.IS_ANONYMOUS)

--- a/src/main/kotlin/com/ulu/repositories/RatingRepository.kt
+++ b/src/main/kotlin/com/ulu/repositories/RatingRepository.kt
@@ -3,6 +3,7 @@ package com.ulu.repositories
 import com.ulu.models.Rating
 import io.micronaut.data.annotation.Repository
 import io.micronaut.data.jpa.repository.JpaRepository
+import java.util.*
 
 @Repository
 interface RatingRepository : JpaRepository<Rating, Long> {
@@ -14,5 +15,5 @@ interface RatingRepository : JpaRepository<Rating, Long> {
     fun findByWhiskeyIdAndUserId(
         whiskeyId: Long,
         userId: Long,
-    ): Rating
+    ): Optional<Rating>
 }

--- a/src/main/kotlin/com/ulu/repositories/WhiskeyRepository.kt
+++ b/src/main/kotlin/com/ulu/repositories/WhiskeyRepository.kt
@@ -3,10 +3,6 @@ package com.ulu.repositories
 import com.ulu.models.Whiskey
 import io.micronaut.data.annotation.Repository
 import io.micronaut.data.jpa.repository.JpaRepository
-import io.micronaut.data.model.Page
-import io.micronaut.data.model.Pageable
 
 @Repository
-interface WhiskeyRepository : JpaRepository<Whiskey, Long> {
-    fun listAll(pageable: Pageable): Page<Whiskey>
-}
+interface WhiskeyRepository : JpaRepository<Whiskey, Long>

--- a/src/main/kotlin/com/ulu/security/JwtPersistenceProvider.kt
+++ b/src/main/kotlin/com/ulu/security/JwtPersistenceProvider.kt
@@ -11,7 +11,6 @@ import jakarta.inject.Singleton
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import reactor.core.publisher.FluxSink
-import java.util.Base64
 
 /**
  * Stores created refresh tokens in JPA repository.
@@ -21,14 +20,14 @@ import java.util.Base64
 @Singleton
 class JwtPersistenceProvider(private val jwtRefreshTokenRepository: JwtRefreshTokenRepository) :
     RefreshTokenPersistence {
-
     override fun persistToken(event: RefreshTokenGeneratedEvent?) {
         if (event?.refreshToken != null && event.authentication?.name != null) {
-            val jwtRefreshToken = JwtRefreshToken(
-                username = event.authentication.name,
-                refreshToken = event.refreshToken,
-                revoked = false
-            )
+            val jwtRefreshToken =
+                JwtRefreshToken(
+                    username = event.authentication.name,
+                    refreshToken = event.refreshToken,
+                    revoked = false,
+                )
             jwtRefreshTokenRepository.saveAndFlush(jwtRefreshToken)
         }
     }

--- a/src/main/kotlin/com/ulu/services/RequestValidatorService.kt
+++ b/src/main/kotlin/com/ulu/services/RequestValidatorService.kt
@@ -4,6 +4,7 @@ import graphql.schema.DataFetchingEnvironment
 import io.micronaut.data.model.Pageable
 import io.micronaut.security.utils.DefaultSecurityService
 import jakarta.inject.Singleton
+import kotlin.math.min
 
 @Singleton
 class RequestValidatorService {
@@ -70,5 +71,26 @@ class RequestValidatorService {
             size = pagingInput["size"] as Int
         }
         return Pageable.from(page, size)
+    }
+
+    /**
+     * Convert list to paged list
+     * */
+    fun <T> getPage(
+        list: List<T>,
+        pageable: Pageable,
+    ): List<T> {
+        // Calculate the index range for the requested page
+        val fromIndex = pageable.number * pageable.size
+
+        // Constraint paging with max size of list
+        val toIndex = min(fromIndex + pageable.size, list.size)
+
+        // Check if fromIndex is within list size
+        return if (fromIndex < list.size) {
+            list.subList(fromIndex, toIndex)
+        } else {
+            emptyList()
+        }
     }
 }

--- a/src/main/kotlin/com/ulu/services/RequestValidatorService.kt
+++ b/src/main/kotlin/com/ulu/services/RequestValidatorService.kt
@@ -4,6 +4,7 @@ import graphql.schema.DataFetchingEnvironment
 import io.micronaut.data.model.Pageable
 import io.micronaut.security.utils.DefaultSecurityService
 import jakarta.inject.Singleton
+import kotlin.math.max
 import kotlin.math.min
 
 @Singleton
@@ -65,11 +66,16 @@ class RequestValidatorService {
         var size = 10
 
         // Get page and size from input
-        val pagingInput = environment.getArgument<Map<*, *>>("paging")
+        val pagingInput = environment.getArgument<Map<String, Int>>("paging")
         if (pagingInput != null) {
-            page = pagingInput["page"] as Int
-            size = pagingInput["size"] as Int
+            page = pagingInput["page"] ?: 0
+            size = pagingInput["size"] ?: 10
         }
+
+        // Limit range of input
+        page = max(0, page)
+        size = max(1, size)
+
         return Pageable.from(page, size)
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,6 +51,8 @@ micronaut:
         enabled: true
       oauth:
         enabled: true
+      logout:
+        enabled: false
     intercept-url-map:
       - pattern: /graphql
         http-method: POST


### PR DESCRIPTION
Bug fixes:
- Fixes paging being applied before filtering the list.

- Also fix logged-in users not getting their getWhiskey(id) request.
The bug occurred when a user was logged in it tried to look at a whiskey, the backend tried to populate the `whiskey.review` field.
If no whiskey was found, it would not set it to null and just return an error.
It now properly sets it to null if a user does not have a review for the whiskey using `Optional`.

- Logout endpoint now removes jwt and refresh token using a set-cookie. The /logout endpoint was previously unreachable due to an underlying /logout endpoint not being explicitly disabled.