### PR TITLE
Fix image auth on server

### DIFF
--- a/src/main/kotlin/com/ulu/controllers/ImageController.kt
+++ b/src/main/kotlin/com/ulu/controllers/ImageController.kt
@@ -83,6 +83,7 @@ class ImageController(
         }
     }
 
+    @Secured(SecurityRule.IS_AUTHENTICATED)
     @Post("/img/profile", consumes = [MediaType.MULTIPART_FORM_DATA], produces = [MediaType.TEXT_PLAIN])
     @Operation(summary = "Upload Profile Image", description = "Uploads a profile image for the authenticated user.")
     @ApiResponses(


### PR DESCRIPTION
It is not possible to upload profile images to the server. It works locally, but get a `403` error when it runs on the server.

This is just a suggestion for something to try (?). Saw that the login and logout endpoints has this tag.

Based on the response, I believe it is Micronaut that returns the error and not Apache. It is not the frontend because it does not work when I test it in Postman.

(I believe the logout problem was a frontend thing that should be fixed in [this pull request](https://github.com/Unrated-Limited-Unlimited/ua-frontend/pull/56))

403 Forbidden. Body of error:
```json
{
    "message": "Forbidden",
    "logref": null,
    "path": null,
    "_links": {
        "self": {
            "href": "/img/profile",
            "templated": false,
            "profile": null,
            "deprecation": null,
            "title": null,
            "hreflang": null,
            "type": null,
            "name": null
        }
    },
    "_embedded": {
        "errors": [
            {
                "message": "Forbidden",
                "logref": null,
                "path": null,
                "_links": {},
                "_embedded": {}
            }
        ]
    }
}
```